### PR TITLE
Redesign: Windows 2000 style UI

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,26 @@
+import Head from "next/head";
+
+export default function App({ Component, pageProps }) {
+  return (
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Confirmação de Presença - Vôlei</title>
+        <style>{`
+          * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+          }
+          body {
+            overflow: hidden;
+            background: #008080;
+            font-family: Tahoma, "MS Sans Serif", Arial, sans-serif;
+            font-size: 11px;
+          }
+        `}</style>
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styles from "../styles/styles.module.css";
 
 function getNextVolleyDay() {
@@ -24,9 +24,115 @@ function formatDate(date) {
   });
 }
 
+function Clock() {
+  const [time, setTime] = useState("");
+
+  useEffect(() => {
+    function updateTime() {
+      const now = new Date();
+      const h = now.getHours().toString().padStart(2, "0");
+      const m = now.getMinutes().toString().padStart(2, "0");
+      setTime(`${h}:${m}`);
+    }
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return <div className={styles.taskbarClock}>{time}</div>;
+}
+
+// Simple SVG icons mimicking Win2K icons
+function QuestionIcon() {
+  return (
+    <svg
+      className={styles.msgIconImage}
+      viewBox="0 0 32 32"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="16" cy="16" r="14" fill="#0000ff" stroke="#000080" strokeWidth="1" />
+      <circle cx="16" cy="16" r="12" fill="#0000cc" />
+      <text
+        x="16"
+        y="22"
+        textAnchor="middle"
+        fill="#ffffff"
+        fontSize="18"
+        fontWeight="bold"
+        fontFamily="Times New Roman, serif"
+      >
+        ?
+      </text>
+    </svg>
+  );
+}
+
+function VolleyIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+    >
+      <circle cx="8" cy="8" r="7" fill="#ffff00" stroke="#808000" strokeWidth="1" />
+      <path d="M4 8 Q8 4 12 8" stroke="#808000" strokeWidth="1" fill="none" />
+      <path d="M4 8 Q8 12 12 8" stroke="#808000" strokeWidth="1" fill="none" />
+      <line x1="8" y1="1" x2="8" y2="15" stroke="#808000" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function FolderIcon() {
+  return (
+    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+      <rect x="2" y="10" width="28" height="20" rx="1" fill="#ffcc00" stroke="#806600" strokeWidth="1" />
+      <path d="M2 10 L2 8 Q2 6 4 6 L12 6 L14 10 Z" fill="#ffdd44" stroke="#806600" strokeWidth="1" />
+      <rect x="3" y="11" width="26" height="18" fill="#ffdd44" />
+    </svg>
+  );
+}
+
+function RecycleBinIcon() {
+  return (
+    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+      <rect x="8" y="12" width="16" height="18" rx="1" fill="#c0c0c0" stroke="#808080" strokeWidth="1" />
+      <rect x="6" y="10" width="20" height="3" rx="1" fill="#d4d0c8" stroke="#808080" strokeWidth="1" />
+      <rect x="12" y="7" width="8" height="4" rx="1" fill="#d4d0c8" stroke="#808080" strokeWidth="1" />
+      <line x1="12" y1="15" x2="12" y2="27" stroke="#808080" strokeWidth="1" />
+      <line x1="16" y1="15" x2="16" y2="27" stroke="#808080" strokeWidth="1" />
+      <line x1="20" y1="15" x2="20" y2="27" stroke="#808080" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function MyComputerIcon() {
+  return (
+    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+      <rect x="4" y="4" width="24" height="18" rx="1" fill="#c0c0c0" stroke="#808080" strokeWidth="1" />
+      <rect x="6" y="6" width="20" height="14" fill="#000080" />
+      <rect x="10" y="23" width="12" height="3" fill="#c0c0c0" stroke="#808080" strokeWidth="1" />
+      <rect x="8" y="26" width="16" height="2" fill="#c0c0c0" stroke="#808080" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function WindowsFlag() {
+  return (
+    <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+      <rect x="1" y="1" width="6" height="6" fill="#ff0000" />
+      <rect x="9" y="1" width="6" height="6" fill="#00aa00" />
+      <rect x="1" y="9" width="6" height="6" fill="#0000ff" />
+      <rect x="9" y="9" width="6" height="6" fill="#ffcc00" />
+    </svg>
+  );
+}
+
 function Home() {
   const nextVolleyDay = getNextVolleyDay();
   const [choice, setChoice] = useState("");
+  const [status, setStatus] = useState("Pronto");
+
   const SIM_LINKS = [
     "https://www.apple.com/br/",
     "https://www.formula1.com/",
@@ -51,58 +157,177 @@ function Home() {
 
   function handleSubmit() {
     if (choice === "yes") {
+      setStatus("Abrindo link...");
       if (Array.isArray(SIM_LINKS) && SIM_LINKS.length > 0) {
         const idx = Math.floor(Math.random() * SIM_LINKS.length);
         openInNewTab(SIM_LINKS[idx]);
-      } else if (typeof SIM_LINKS === "string" && SIM_LINKS) {
-        openInNewTab(SIM_LINKS);
       } else {
         alert("Nenhum link disponível para 'Sim'.");
       }
+      setTimeout(() => setStatus("Pronto"), 1500);
     } else if (choice === "no") {
+      setStatus("Abrindo link...");
       if (NAO_LINK) {
         openInNewTab(NAO_LINK);
       } else {
         alert("Nenhum link disponível para 'Não'.");
       }
+      setTimeout(() => setStatus("Pronto"), 1500);
     } else {
       alert("Por favor selecione 'Sim' ou 'Não' antes de enviar.");
     }
   }
 
+  function handleClose() {
+    setStatus("Fechando...");
+    setTimeout(() => setStatus("Pronto"), 800);
+  }
+
   return (
-    <div className={styles.container}>
-      <h1 className={styles.subtitle}>
-        Tu vai no vôlei <strong>{formatDate(nextVolleyDay)}</strong> ??
-      </h1>
-
-      <div className={styles.radioGroup}>
-        <label>
-          <input
-            type="radio"
-            name="volley"
-            value="yes"
-            checked={choice === "yes"}
-            onChange={() => setChoice("yes")}
-          />
-          Sim
-        </label>
-
-        <label style={{ marginLeft: 16 }}>
-          <input
-            type="radio"
-            name="volley"
-            value="no"
-            checked={choice === "no"}
-            onChange={() => setChoice("no")}
-          />
-          Não
-        </label>
+    <div className={styles.desktop}>
+      {/* Desktop Icons */}
+      <div className={styles.desktopIcons}>
+        <div className={styles.desktopIcon}>
+          <MyComputerIcon />
+          <span className={styles.desktopIconLabel}>Meu Computador</span>
+        </div>
+        <div className={styles.desktopIcon}>
+          <FolderIcon />
+          <span className={styles.desktopIconLabel}>Meus Documentos</span>
+        </div>
+        <div className={styles.desktopIcon}>
+          <RecycleBinIcon />
+          <span className={styles.desktopIconLabel}>Lixeira</span>
+        </div>
       </div>
 
-      <button type="button" onClick={handleSubmit} disabled={!choice}>
-        Enviar resposta
-      </button>
+      {/* Main Window */}
+      <div className={styles.window}>
+        {/* Title Bar */}
+        <div className={styles.titleBar}>
+          <div className={styles.titleBarLeft}>
+            <div className={styles.titleBarIcon}>
+              <VolleyIcon />
+            </div>
+            <span className={styles.titleBarText}>Confirmação de Presença</span>
+          </div>
+          <div className={styles.titleBarButtons}>
+            <button
+              className={styles.titleBarBtn}
+              onClick={() => {}}
+              aria-label="Minimizar"
+            >
+              _
+            </button>
+            <button
+              className={styles.titleBarBtn}
+              onClick={() => {}}
+              aria-label="Maximizar"
+            >
+              ▢
+            </button>
+            <button
+              className={styles.titleBarBtn}
+              onClick={handleClose}
+              aria-label="Fechar"
+              style={{ fontWeight: "bold" }}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        {/* Window Body */}
+        <div className={styles.windowContent}>
+          <div className={styles.msgBox}>
+            {/* Question area */}
+            <div className={styles.msgIcon}>
+              <QuestionIcon />
+              <div className={styles.msgText}>
+                <span className={styles.msgTextBold}>
+                  Tu vai no vôlei{" "}
+                  <span style={{ color: "#000080" }}>
+                    {formatDate(nextVolleyDay)}
+                  </span>
+                  ??
+                </span>
+                <br />
+                <br />
+                Selecione uma opção abaixo e clique em{" "}
+                <strong>Enviar resposta</strong>.
+              </div>
+            </div>
+
+            <div className={styles.divider} />
+
+            {/* Radio group */}
+            <div className={styles.groupBox}>
+              <span className={styles.groupBoxLegend}>Resposta</span>
+              <div className={styles.radioGroup}>
+                <label className={styles.radioLabel}>
+                  <input
+                    type="radio"
+                    name="volley"
+                    value="yes"
+                    checked={choice === "yes"}
+                    onChange={() => setChoice("yes")}
+                  />
+                  Sim
+                </label>
+                <label className={styles.radioLabel}>
+                  <input
+                    type="radio"
+                    name="volley"
+                    value="no"
+                    checked={choice === "no"}
+                    onChange={() => setChoice("no")}
+                  />
+                  Não
+                </label>
+              </div>
+            </div>
+
+            <div className={styles.divider} />
+
+            {/* Buttons */}
+            <div className={styles.buttonRow}>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!choice}
+                className={`${styles.btn} ${choice ? styles.btnFocused : ""}`}
+              >
+                Enviar resposta
+              </button>
+              <button
+                type="button"
+                onClick={() => setChoice("")}
+                className={styles.btn}
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Status Bar */}
+        <div className={styles.statusBar}>
+          <div className={styles.statusBarPanel}>{status}</div>
+        </div>
+      </div>
+
+      {/* Taskbar */}
+      <div className={styles.taskbar}>
+        <button className={styles.startButton}>
+          <WindowsFlag />
+          <span>Iniciar</span>
+        </button>
+        <div className={styles.taskbarTask}>
+          <VolleyIcon />
+          <span>Confirmação de Presença</span>
+        </div>
+        <Clock />
+      </div>
     </div>
   );
 }

--- a/styles/styles.module.css
+++ b/styles/styles.module.css
@@ -1,15 +1,351 @@
-.container {
-  padding: 40px;
-  font-family: Arial, sans-serif;
-  text-align: center;
+/* Windows 2000 Design System */
+
+/* ── Desktop ── */
+.desktop {
+  width: 100vw;
+  min-height: 100vh;
+  background-color: #008080;
+  background-image: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  font-family: "Tahoma", "MS Sans Serif", Arial, sans-serif;
+  font-size: 11px;
+  overflow: hidden;
 }
 
-.title {
-  font-size: 40px;
+/* ── Taskbar ── */
+.taskbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 28px;
+  background: #d4d0c8;
+  border-top: 1px solid #ffffff;
+  display: flex;
+  align-items: center;
+  padding: 0 2px;
+  gap: 2px;
+  z-index: 1000;
+  box-shadow: inset 0 1px 0 #ffffff;
+}
+
+.startButton {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 6px 0 4px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  cursor: pointer;
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  font-weight: bold;
+  color: #000000;
+  outline: none;
+}
+
+.startButton:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+.startIcon {
+  width: 16px;
+  height: 16px;
+}
+
+.taskbarClock {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 6px;
+  background: #d4d0c8;
+  border: 1px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
   color: #000000;
 }
 
-.description {
-  margin-top: 10px;
-  font-size: 20px;
+.taskbarTask {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 8px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  cursor: default;
+}
+
+/* ── Window ── */
+.window {
+  width: 400px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  box-shadow: 2px 2px 0 #000000;
+  position: relative;
+  z-index: 100;
+  margin-bottom: 30px;
+}
+
+/* ── Title Bar ── */
+.titleBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 3px 3px 4px;
+  background: linear-gradient(to right, #0a246a, #a6caf0);
+  height: 22px;
+  cursor: default;
+  user-select: none;
+}
+
+.titleBarLeft {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.titleBarIcon {
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.titleBarText {
+  color: #ffffff;
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  font-weight: bold;
+}
+
+.titleBarButtons {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.titleBarBtn {
+  width: 16px;
+  height: 14px;
+  background: #d4d0c8;
+  border: 1px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 9px;
+  font-family: "Marlett", "Tahoma", Arial, sans-serif;
+  color: #000000;
+  padding: 0;
+  outline: none;
+}
+
+.titleBarBtn:active {
+  border-color: #808080 #ffffff #ffffff #808080;
+}
+
+/* ── Window Content ── */
+.windowContent {
+  padding: 12px;
+}
+
+/* ── Message Box area ── */
+.msgBox {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.msgIcon {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.msgIconImage {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+.msgText {
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  line-height: 1.5;
+}
+
+.msgTextBold {
+  font-weight: bold;
+}
+
+/* ── Divider ── */
+.divider {
+  height: 2px;
+  background: linear-gradient(to right, #808080, #d4d0c8);
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  margin: 8px 0;
+}
+
+/* ── Groupbox ── */
+.groupBox {
+  border: 1px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  padding: 10px 10px 10px 10px;
+  margin: 4px 0;
+  position: relative;
+}
+
+.groupBoxLegend {
+  position: absolute;
+  top: -7px;
+  left: 8px;
+  background: #d4d0c8;
+  padding: 0 4px;
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+}
+
+/* ── Radio Buttons ── */
+.radioGroup {
+  display: flex;
+  gap: 20px;
+  padding: 6px 0;
+}
+
+.radioLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  cursor: pointer;
+  user-select: none;
+}
+
+.radioLabel input[type="radio"] {
+  margin: 0;
+  cursor: pointer;
+  accent-color: #000080;
+}
+
+/* ── Buttons ── */
+.buttonRow {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.btn {
+  height: 23px;
+  min-width: 75px;
+  padding: 0 12px;
+  background: #d4d0c8;
+  border: 2px solid;
+  border-color: #ffffff #808080 #808080 #ffffff;
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  cursor: pointer;
+  outline: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 1px 1px 0 #000000;
+}
+
+.btn:active:not(:disabled) {
+  border-color: #808080 #ffffff #ffffff #808080;
+  box-shadow: none;
+  padding-top: 1px;
+  padding-left: 13px;
+}
+
+.btn:disabled {
+  color: #808080;
+  text-shadow: 1px 1px 0 #ffffff;
+  cursor: default;
+}
+
+.btnFocused {
+  outline: 1px dotted #000000;
+  outline-offset: -4px;
+}
+
+/* ── Status bar ── */
+.statusBar {
+  display: flex;
+  align-items: center;
+  height: 20px;
+  border-top: 1px solid #808080;
+  padding: 0 4px;
+  gap: 4px;
+}
+
+.statusBarPanel {
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  padding: 2px 4px;
+  border: 1px solid;
+  border-color: #808080 #ffffff #ffffff #808080;
+  flex: 1;
+}
+
+/* ── Desktop Icons ── */
+.desktopIcons {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.desktopIcon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  cursor: pointer;
+  width: 64px;
+}
+
+.desktopIconImg {
+  width: 32px;
+  height: 32px;
+}
+
+.desktopIconLabel {
+  font-family: "Tahoma", Arial, sans-serif;
+  font-size: 11px;
+  color: #ffffff;
+  text-align: center;
+  text-shadow: 1px 1px 2px #000000;
+  word-break: break-word;
+  max-width: 64px;
+}
+
+.desktopIcon:hover .desktopIconLabel {
+  background: #0a246a;
+  color: #ffffff;
 }


### PR DESCRIPTION
Redesigns the volleyball attendance confirmation page (`/`) with a full Windows 2000 aesthetic.

### Changes
- **`pages/index.js`** — Complete redesign with Win2K chrome: classic dialog window with blue gradient title bar, minimize/maximize/close buttons, 3D beveled borders, group box with `Resposta` legend, classic radio buttons, disabled-state button with dotted focus ring, and a status bar showing "Pronto" / "Abrindo link..."
- **`styles/styles.module.css`** — All-new Win2K CSS: teal `#008080` desktop, silver `#d4d0c8` window chrome, inset/raised border-color bevel trick, Tahoma font, taskbar with Start button + clock, and desktop icons (Meu Computador, Meus Documentos, Lixeira)
- **`pages/_app.js`** — New global reset + `overflow: hidden` body so the desktop fills the viewport cleanly
- Inline SVG pixel-art icons for the volleyball ball, Windows flag, folder, recycle bin, and monitor